### PR TITLE
Example debug code + logger convention + bugfix

### DIFF
--- a/my_pyscf/mcpdft/cmspdft3.py
+++ b/my_pyscf/mcpdft/cmspdft3.py
@@ -282,7 +282,7 @@ if __name__ == '__main__':
     print (("Molden files with intermediate-state NOs are in "
             "h2o_sapdft_int?.molden"))
     with lib.temporary_env (mc, ci=ci_int):
-        # ^ See line 225 
+        # ^ See line 244
         for i in range (3):
             fname = 'h2o_sapdft_int{}.molden'.format (i)
             molden.from_sa_mcscf (mc, fname, state=i, cas_natorb=True)

--- a/my_pyscf/mcpdft/cmspdft3.py
+++ b/my_pyscf/mcpdft/cmspdft3.py
@@ -82,11 +82,11 @@ def kernel (mc,nroots=None):
 # be clear how this works.
     rowscol2ind = np.zeros ((nroots, nroots), dtype=np.integer)
     rowscol2ind[(rows,col)] = list (range (pairs)) # 0,1,2,3,...
-    rowscol2ind += rowscol2ind.T # lower triangle -> upper triangle
+    rowscol2ind += rowscol2ind.T # Now it can handle both k>l and l>k 
     rowscol2ind[np.diag_indices(nroots)] = -1 # Makes sure it crashes if you look
-                                              # for the diagonal element, since
-                                              # rows, col don't include the diagonal
-                                              # element!
+                                              # for k==l, since that's the density 
+                                              # matrix and we compute that with a 
+                                              # different function.
     def w_klmn(k,l,m,n,ci):
         casdm1 = mc.fcisolver.states_make_rdm1 (ci,mc_1root.ncas,mc_1root.nelecas)
         # MRH: don't you also need to put casdm1 into the AO basis/recompute dm1?

--- a/my_pyscf/mcpdft/cmspdft3.py
+++ b/my_pyscf/mcpdft/cmspdft3.py
@@ -296,7 +296,7 @@ if __name__ == '__main__':
     print (("Molden files with intermediate-state NOs are in "
             "h2o_sapdft_int?.molden"))
     with lib.temporary_env (mc, ci=ci_int):
-        # ^ See line 244
+        # ^ See line 258
         for i in range (3):
             fname = 'h2o_sapdft_int{}.molden'.format (i)
             molden.from_sa_mcscf (mc, fname, state=i, cas_natorb=True)

--- a/my_pyscf/mcpdft/cmspdft3.py
+++ b/my_pyscf/mcpdft/cmspdft3.py
@@ -89,6 +89,20 @@ def kernel (mc,nroots=None):
                                               # element!
     def w_klmn(k,l,m,n,ci):
         casdm1 = mc.fcisolver.states_make_rdm1 (ci,mc_1root.ncas,mc_1root.nelecas)
+        # MRH: don't you also need to put casdm1 into the AO basis/recompute dm1?
+        dm1 = np.dot(casdm1,mo_cas.T)
+        dm1 = np.dot(mo_cas,dm1).transpose(1,0,2)
+        # MRH: IMO it's more elegant to rewrite these functions to take the density
+        # matrices dm1_cirot and tdm1 as you compute them for the gradient downstairs,
+        # since it's the same density matrices for both derivatives. Then this whole
+        # function could be like 5 lines long:
+        #   d = dm1_cirot[k] if k==l else tdm1[rowscol2ind[k,l]]
+        #   dm1_g = mc_1root._scf.get_j (dm=d)
+        #   d = dm1_cirot[m] if m==n else tdm1[rowscol2ind[m,n]]
+        #   w = (dm1_g*d).sum ((0,1))
+        #   return w
+        # But I'll leave it like this so you can see what's going on more clearly in
+        # the github "files changed" tab.
         trans12_tdm1, trans12_tdm2 = mc.fcisolver.states_trans_rdm12(ci[col],ci[rows],mc_1root.ncas,mc_1root.nelecas)
         if k==l:
             dm1_g = mc_1root._scf.get_j (dm=dm1[k])

--- a/my_pyscf/mcpdft/cmspdft3.py
+++ b/my_pyscf/mcpdft/cmspdft3.py
@@ -5,16 +5,22 @@ from pyscf import gto, dft, ao2mo, fci, mcscf, lib
 from pyscf.lib import logger, temporary_env
 from pyscf.mcscf import mc_ao2mo
 from pyscf.mcscf.addons import StateAverageMCSCFSolver, state_average_mix, state_average_mix_, state_average
-from mrh.my_pyscf.grad.mcpdft import Gradients
 from mrh.util.rdm import get_2CDM_from_2RDM, get_2CDMs_from_2RDMs
 from mrh.my_pyscf.mcpdft import pdft_veff
 from mrh.my_pyscf.mcpdft.otpd import get_ontop_pair_density
 from mrh.my_pyscf.mcpdft.otfnal import otfnal, transfnal, ftransfnal
 from mrh.my_pyscf import mcpdft
+from mrh.my_pyscf.grad.mcpdft import Gradients
+# MRH: this ^ import can cause recursive inheritance crashes if it appears
+# higher in this list, before other mcpdft modules. I need to fix it but in the
+# meantime just make sure it's the last import and it should be OK.
 
-def kernel (mc,nroots):
+def kernel (mc,nroots=None):
+# MRH: made nroots a kwarg so that this function can be called more simply
+    if nroots is None: nroots = mc.fcisolver.nroots
 
 #Initialization
+        
     mc_1root = mc
     mc_1root = mcscf.CASCI (mc._scf, mc.ncas, mc.nelecas)
     mc_1root.fcisolver = fci.solver (mc._scf.mol, singlet = False, symm = False)
@@ -34,12 +40,41 @@ def kernel (mc,nroots):
     t = np.zeros((nroots,nroots))
     t_old = np.zeros((nroots,nroots))
 
+    log = lib.logger.new_logger (mc, mc.verbose)
+    log.info ("Entering cmspdft3.kernel")
+# MRH: PySCF convention is never to use the "print" function in method code.
+# All I/O in published PySCF code goes through the pyscf.lib.logger module.
+# This prints data to an output file specified by the user like
+# mol = gto.M (atom = ..., verbose = lib.logger.INFO, output = 'fname.log')
+# If no output file is specified, it goes to the STDOUT as if it were a print
+# command. The different pyscf.lib.logger functions, "note", "info", "debug",
+# and some others, correspond to different levels of verbosity. In the above
+# example, log.note and log.info commands would print information to 
+# 'fname.log', but "debug" commands, which are a higher level, are skipped.
+# I changed all the print commands in this function to log.debug or log.info
+# commands.
+
 #Print the First Coulomb Energy
     j = mc_1root._scf.get_j (dm=dm1)
     e_coul = (j*dm1).sum((1,2)) / 2
-    print ("e_coul", e_coul)
-    print("e_coul sum",e_coul.sum())
-   
+    log.debug ("Reference state e_coul {}".format (e_coul)) 
+    log.info ("Reference state e_coul sum = %f",e_coul.sum())
+# MRH: There are a couple of things going on here. First of all, the two
+# statements share different levels of detail, so I use different verbosities:
+# "debug" (only printed if the user has verbose=DEBUG or higher) for the list
+# of all Coulomb energies and "info" (verbose=INFO is the default if an output
+# file is specified) for the sum. Secondly, I am showing two separate ways of
+# formatting strings in Python. log.xxx () knows how to parse the "old" Python
+# string-formatting rules, which is what I've used in the log.info command, but
+# it doesn't know how to interpret a list of arguments the way "print" does, so
+# you have to pass it only one single string. The other way to do this is with
+# "new" python formatting, which I think is simpler:
+# print ("{} and {} and {}".format (a, b, c))
+# is basically identical to
+# print (a, "and", b, "and", c)
+# but you can only use the former in log.xxx:
+# log.xxx ("{} and {} and {}".format (a, b, c))
+
 #Hessian Functions
     def w_klmn(k,l,m,n,ci):
         casdm1 = mc.fcisolver.states_make_rdm1 (ci,mc_1root.ncas,mc_1root.nelecas)
@@ -86,7 +121,7 @@ def kernel (mc,nroots):
     ci_old = ci_array
     thrs = 1.0e-06
     e_coul_old = e_coul
-
+    conv = False
 
 #################
 #Begin Loop 
@@ -94,7 +129,7 @@ def kernel (mc,nroots):
 
 
     for it in range(maxiter):
-        print ("****iter ",it,"***********")
+        log.info ("****iter {} ***********".format (it))
        
 #       Form U
         U = linalg.expm(t) 
@@ -117,7 +152,8 @@ def kernel (mc,nroots):
 #       Print New E coul and difference
         j = mc_1root._scf.get_j (dm=dm1_cirot)
         e_coul_new = (j*dm1_cirot).sum((1,2)) / 2
-        print("Sum e_coul",e_coul_new.sum(), "difference", e_coul_new.sum()-e_coul_old.sum())
+        log.info ("Sum e_coul = {} ; difference = {}".format (e_coul_new.sum(), 
+            e_coul_new.sum()-e_coul_old.sum()))
  
 #       Compute Gradient
         dg = mc_1root._scf.get_j (dm=tdm1)
@@ -125,12 +161,13 @@ def kernel (mc,nroots):
         grad2 = (dg*dm1_cirot[col]).sum((1,2))
         grad = 4*(grad1 + grad2)
         grad_norm = np.linalg.norm(grad)
-        print("grad norm", grad_norm)
+        log.debug ("grad: {}".format (grad))
+        log.info ("grad norm = %f", grad_norm)
 
 
         if grad_norm < thrs:
-            print("CONVERGED")
-            ci_final = ci_rot
+            conv = True
+            # ci_final = ci_rot # best just to use ci_rot
             break
 
 #       Hessian
@@ -143,6 +180,12 @@ def kernel (mc,nroots):
                 n=col[j]
                 hess[i,j] = v_klmn(k,l,m,n,ci_rot)+v_klmn(l,k,n,m,ci_rot)-v_klmn(k,l,n,m,ci_rot)-v_klmn(l,k,m,n,ci_rot)
 
+#       MRH: print some diagnostic stuff, but only do the potentially-expensive
+#       diagonalization if the user-specified verbosity is high enough
+        if log.verbose >= lib.logger.DEBUG:
+            evals, evecs = linalg.eigh (hess)
+            log.debug ("Hessian eigenvalues: {}".format (evals))
+
 #       Make T
 
         t_add = linalg.solve(hess,-grad)
@@ -150,7 +193,14 @@ def kernel (mc,nroots):
         t[np.tril_indices(t.shape[0], k = -1)] = t_add
 
         t = t - t.T
-        t = t + t_old
+        # t = t + t_old
+        # MRH: I don't think you add them. They're expressed in different 
+        # bases, and anyway ci_rot already has the effect of t_old in it. On
+        # iteration zero, say ci_rot is called ci0. Then on iteration 1, it's
+        # ci1 = expm (t1) ci0
+        # Then on iteration 2, it's
+        # ci2 = expm (t2) ci1 = expm (t2) expm (t1) ci0
+        # and so forth. So you don't need to keep the running sum. 
         t_old = t.copy()
 
 #       Reset Old Values
@@ -161,15 +211,62 @@ def kernel (mc,nroots):
 #########################
 # End Loop
 
+    if conv:
+        log.note ("CMS-PDFT intermediate state determination CONVERGED")
+    else:
+        log.note (("CMS-PDFT intermediate state determination did not converge"
+                   " after {} cycles").format (it))
+
 # Intermediate Energies 
 # Run MC-PDFT
-    mc.ci = ci_final
+    #mc.ci = ci_final
     E_int = np.zeros((nroots)) 
-    for i in range(nroots):    
-        E_int [i]= mcpdft.mcpdft.kernel(mc,mc.otfnal,i)[0]
-    print ("E_int", E_int)
+    with lib.temporary_env (mc, ci=ci_rot):
+        # This ^ ~temporarily sets mc.ci to ci_rot
+        # As soon as you leave this indent block, it returns to
+        # whatever it was before. Convenient! Of course, it would
+        # be WAY BETTER for me to just implement ci as a kwarg
+        # in mcpdft.kernel.
+        for i in range(nroots):    
+            E_int [i]= mcpdft.mcpdft.kernel(mc,mc.otfnal,i)[0]
+    log.info ("CMS-PDFT intermediate state energies: {}".format (E_int))
 
 
-    return
+    return conv, E_int, ci_rot
 
+
+if __name__ == '__main__':
+    # This ^ is a convenient way to debug code that you are working on. The
+    # code in this block will only execute if you run this python script as the
+    # input directly: "python cmspdft3.py".
+
+    from pyscf import scf
+    from mrh.my_pyscf.tools import molden # My version is better for MC-SCF
+    from mrh.my_pyscf.fci import csf_solver
+    xyz = '''O  0.00000000   0.08111156   0.00000000
+             H  0.78620605   0.66349738   0.00000000
+             H -0.78620605   0.66349738   0.00000000'''
+    mol = gto.M (atom=xyz, basis='sto-3g', symmetry=False, output='cmspdft3.log', verbose=lib.logger.DEBUG)
+    mf = scf.RHF (mol).run ()
+    mc = mcpdft.CASSCF (mf, 'tPBE', 4, 4).set (fcisolver = csf_solver (mol, 1))
+    mc = mc.state_average ([1.0/3,]*3).run ()
+    molden.from_sa_mcscf (mc, 'h2o_sapdft_sa.molden', cas_natorb=True)
+    # ^ molden file with state-averaged NOs
+    for i in range (3):
+        fname = 'h2o_sapdft_ref{}.molden'.format (i)
+        # ^ molden file with ith reference state NOs
+        molden.from_sa_mcscf (mc, fname, state=i, cas_natorb=True)
+
+    conv, E_int, ci_int = kernel (mc, 3)
+    print ("The iteration did{} converge".format ((' not','')[int (conv)]))
+    print ("The intermediate-state energies are",E_int)
+    print (("Molden files with intermediate-state NOs are in "
+            "h2o_sapdft_int?.molden"))
+    with lib.temporary_env (mc, ci=ci_int):
+        # ^ See line 225 
+        for i in range (3):
+            fname = 'h2o_sapdft_int{}.molden'.format (i)
+            molden.from_sa_mcscf (mc, fname, state=i, cas_natorb=True)
+    
+    print ("See cmspdft3.log for more information")
 

--- a/my_pyscf/mcpdft/mcpdft.py
+++ b/my_pyscf/mcpdft/mcpdft.py
@@ -89,7 +89,8 @@ def kernel (mc, ot, root=-1):
         assert (abs (e_err) < 1e-8), e_err
         if isinstance (mc_1root.e_tot, float):
             e_err = mc_1root.e_tot - (Vnn + Te_Vne + E_j + E_x + E_c)
-            assert (abs (e_err) < 1e-8), e_err
+            # assert (abs (e_err) < 1e-8), e_err
+            # TODO: come up with a better way to handle this for CMS-PDFT
     if abs (hyb_x) > 1e-10 or abs (hyb_c) > 1e-10:
         logger.debug (ot, 'Adding %s * %s CAS exchange, %s * %s CAS correlation to E_ot', hyb_x, E_x, hyb_c, E_c)
     t0 = logger.timer (ot, 'Vnn, Te, Vne, E_j, E_x', *t0)

--- a/my_pyscf/tools/molden.py
+++ b/my_pyscf/tools/molden.py
@@ -1,8 +1,12 @@
-from pyscf.tools.molden import from_mo, from_mcscf
+from pyscf.lib import temporary_env
+from pyscf.tools.molden import from_mo, IGNORE_H
+from pyscf.tools.molden import from_mcscf as pyscf_from_mcscf
 import numpy as np
 
 def from_sa_mcscf (mc, fname, state=None, cas_natorb=False, cas_mo_energy=False, **kwargs):
-    if state is None: return from_mcscf (mc, fname, cas_natorb=cas_natorb, **kwargs)
+    if state is None: 
+        if cas_mo_energy: return pyscf_from_mcscf (mc, fname, cas_natorb=cas_natorb, **kwargs)
+        else: return from_mcscf (mc, fname, cas_natorb=cas_natorb, **kwargs)
     casdm1 = mc.fcisolver.states_make_rdm1 (mc.ci, mc.ncas, mc.nelecas)[state]
     mo_coeff, mo_ci, mo_energy = mc.canonicalize (ci=mc.ci[state], cas_natorb=cas_natorb, casdm1=casdm1)
     if not cas_mo_energy:
@@ -11,9 +15,24 @@ def from_sa_mcscf (mc, fname, state=None, cas_natorb=False, cas_mo_energy=False,
     # and apply them also to the StateAverageMCSCFSolver instance
     mo_occ = np.zeros_like (mo_energy)
     mo_occ[:mc.ncore] = 2.0
-    ci = mc.ci
+    ci = [c.copy () for c in mc.ci]
     ci[state] = mo_ci
     mo_occ[mc.ncore:][:mc.ncas] = mc.fcisolver.states_make_rdm1 (ci, mc.ncas, mc.nelecas)[state].diagonal ()
     return from_mo (mc.mol, fname, mo_coeff, occ=mo_occ, ene=mo_energy, **kwargs)
 
 
+def from_lasscf (las, fname, **kwargs):
+    mo_coeff, mo_ene, mo_occ = las.canonicalize ()[:3]
+    return from_mo (las.mol, fname, mo_coeff, occ=mo_occ, ene=mo_ene, **kwargs)
+
+def from_mcscf (mc, filename, ignore_h=IGNORE_H, cas_natorb=False):
+    ncore, ncas = mc.ncore, mc.ncas
+    nocc = ncore + ncas
+    mc_can = mc.canonicalize
+    def no_active_ene (sort=True, cas_natorb=cas_natorb):
+        mo_coeff, ci, mo_energy = mc_can (sort=sort, cas_natorb=cas_natorb)
+        mo_energy[ncore:nocc] = 0.0
+        return mo_coeff, ci, mo_energy
+    with temporary_env (mc, canonicalize=no_active_ene):
+        ret = pyscf_from_mcscf (mc, filename, ignore_h=IGNORE_H, cas_natorb=cas_natorb)
+    return ret


### PR DESCRIPTION
Hey Thais, you don't have to accept this pull request if you don't want, I just wanted to show you some features of Python and PySCF. I didn't change much of your actual code, except that I don't think we should sum t over successive iterations, as I try to explain in the comment. I notice that for the water molecule, the Hessian we compute isn't positive-definite (one negative eigenvalue), but it looks like it doesn't matter because the gradient is so small? This might be an issue in general though.

I added an `if __name__ == "__main__":` block to the end of
cmspdft3.py, which is code that is only executed when the file
itself is run like "python cmspdft3.py". This code shows how to
look at the NOs of the intermediate states. I also changed the
"print" commands in cmspdft3.kernel to PySCF logger commands and
tried to explain in comments how to use them. I also edited the
code itself by removing the running summation of t, which I think
isn't correct, and set it up to return without crashing even if
it doesn't converge after maxiter (it now returns a boolean that
tells you whether or not it worked).